### PR TITLE
Reorder arguments to match function definition

### DIFF
--- a/bn.h
+++ b/bn.h
@@ -36,7 +36,7 @@ void bn_zero(bn *p);
 
 void bn_swap(bn *a, bn *b);
 
-void bn_lshift(const bn *q, unsigned int bits, bn *p);
+void bn_lshift(const bn *p, unsigned int bits, bn *q);
 
 /* S = A + B */
 void bn_add(const bn *a, const bn *b, bn *s);


### PR DESCRIPTION
Function 'bn_lshift' argument different in declaration and definition

[bn.h]
```cpp
void bn_lshift(const bn *q, unsigned int bits, bn *p);
                         ^                         ^
```
[bignum.c]
```cpp
void bn_lshift(const bn *p, unsigned int bits, bn *q){ ... }
                         ^                         ^
```

Change declaration to match definition.